### PR TITLE
Return public struct interface. add rockspec and publish script.

### DIFF
--- a/lua-struct.rockspec
+++ b/lua-struct.rockspec
@@ -1,0 +1,27 @@
+package = "lua-struct"
+version = "@VERSION@-@REVISION@"
+
+source = {
+  url = "git://github.com/iryont/lua-struct.git"
+}
+
+description = {
+  summary = "Implementation of binary packing/unpacking in pure lua",
+  detailed = [[
+    Implementation of binary packing/unpacking in pure lua
+    You can use it to pack and unpack binary data in pure lua. The idea is very similar to PHP unpack and pack functions."
+  ]],
+  homepage = "https://github.com/iryont/lua-struct",
+  license = "MIT/X11"
+}
+
+dependencies = {}
+
+build = {
+  type = 'none',
+  install = {
+    lua = {
+      ['struct'] = 'struct.lua'
+    }
+  }
+}

--- a/publish
+++ b/publish
@@ -1,0 +1,41 @@
+# version=$(git tag -l | tail -1)
+
+version="1.0.0"
+rev="1" # rev="1"
+
+name="lua-struct-$version-$rev"
+
+tmp="$TEMPDIR"
+if [ -z "$tmp" ]; then
+   tmp="$HOME"
+fi
+
+src="$(cd "$(dirname $0)" && pwd)"
+
+cd $tmp
+rm -f "$name"
+ln -sf "$src" "$name"
+
+echo "Creating $tmp/$name.src.rock"
+tar -czvpf "$name.src.rock" \
+    --dereference \
+    --exclude "$name/.git*" \
+    --exclude "$name/*.o" \
+    --exclude "$name/*.so" \
+    --exclude "$name/lua-struct.rockspec" \
+    --exclude "$name/rockspecs" \
+    --exclude "$name/server" \
+    --exclude "$name/coronasdk-example" \
+    --exclude "$name/example" \
+    --exclude "$name/*~" \
+    --exclude "$name/.DS_Store" \
+    --exclude "$name/publish" \
+    --exclude "$name/$(basename $0)" \
+    "$name"
+
+echo "Creating $tmp/$name.rockspec"
+cat "$src/lua-struct.rockspec" | \
+    sed \
+      -e s/@VERSION@/$version/ \
+      -e s/@REVISION@/$rev/ > \
+    "$name.rockspec"

--- a/struct.lua
+++ b/struct.lua
@@ -30,8 +30,8 @@ function struct.pack(format, ...)
       local sign = 0
 
       if val < 0 then
-        sign = 1 
-        val = -val 
+        sign = 1
+        val = -val
       end
 
       local mantissa, exponent = math.frexp(val)
@@ -167,3 +167,5 @@ function struct.unpack(format, stream)
 
   return unpack(vars)
 end
+
+return struct


### PR DESCRIPTION
Hi @iryont, thanks for this piece of code.

On this pull-request I've [exposed the functions](https://github.com/endel/lua-struct/blob/luarocks/struct.lua#L171) to whoever requires it.

I've added a rockspec template file, to be able to integrate this with [luarocks](http://luarocks.org) package manager, allowing developers to install and use it easily. There is also a `publish` script, which creates the `.rockspec` file in your home directory.

If you accept this pull-request, to publish the package on luarocks you'd need to follow this steps:
- Create a tag (release) on Github with the version number (ex. `1.0.0`)
- Pull remote changes from Github (`git pull`)
- Run `./publish` script, which will create the `lua-struct-1.0.0-1.rockspec` on your home directory.
- Run `luarocks upload ~/lua-struct-1.0.0-1.rockspec`

I've published it to my personal account as demonstration here: http://luarocks.org/modules/endel/endel-struct - which I'd delete once you see this :)

Thanks again
